### PR TITLE
Updating file paths used in vcf_chrom_counter example.

### DIFF
--- a/6_miniwdl_course/2b_vcf_chrom_counter.sh
+++ b/6_miniwdl_course/2b_vcf_chrom_counter.sh
@@ -1,6 +1,6 @@
 ```bash
-miniwdl run vcf_chrom_counter.wdl \
-  vcf_gz=https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/NA12878_HG001/latest/GRCh38/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz \
-  tbi=https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/NA12878_HG001/latest/GRCh38/HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz.tbi \
+miniwdl run 2a_vcf_chrom_counter.wdl \
+  vcf_gz=https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/NA12878_HG001/latest/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz \
+  tbi=https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/NA12878_HG001/latest/GRCh38/HG001_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi \
   --verbose
 ```


### PR DESCRIPTION
The file paths given in the video and 2b_vcf_chrom_counter.sh no longer appear to exist (as of 2021-10-15). This PR replaces them with existant paths. It also updates the name of the WDL script (adds the `2a_` prefix).