### PR TITLE
Specify memory as an Int instead of a string 

### DIFF
--- a/3_genomic_tool_pipelines/1_bamstats/bamstats.json
+++ b/3_genomic_tool_pipelines/1_bamstats/bamstats.json
@@ -1,3 +1,3 @@
-{   "BamstatsWorkflow.mem_gb": "10",   
+{   "BamstatsWorkflow.mem_gb": 10,   
     "BamstatsWorkflow.bam_input": "input.bam" 
 }


### PR DESCRIPTION
This fix makes it possible to run the example in both miniwdl and cromwell (miniwdl does not like the Int to be in quotes)